### PR TITLE
Specify minimum perl version in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -246,6 +246,9 @@ WriteMakefile(
     ($ExtUtils::MakeMaker::VERSION >= 6.3002
      ? ('LICENSE'=> 'perl')
      : ()),
+    ($ExtUtils::MakeMaker::VERSION >= 6.48
+     ? ('MIN_PERL_VERSION' => '5.6.0')
+     : ()),
     PREREQ_PM => { 'Time::HiRes' => 0,
 		   'File::Temp'  => 0,
 		   'HTTP::Tiny'  => 0,


### PR DESCRIPTION
A tiny PR to specify the minimum perl version as recommended at [CPANTS](https://cpants.cpanauthors.org/dist/Alien-Gnuplot).

This work was done as part of the [CPAN PR Challenge](http://cpan-prc.org/).