### PR TITLE
Replace explicit STDIN read with prompt () in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -80,24 +80,7 @@ The minimum recommended version is $Alien::Gnuplot::GNUPLOT_RECOMMENDED_VERSION.
 
 	my $install_flag;
 
-	if( (-t STDIN  or $^O =~ m/MSWin/) and 
-	      ! (  $ENV{AUTOMATED_TESTING} or $ENV{PERL_MM_USE_DEFAULT}  ) 
-	    ) {
-
-	    print "\nGnuplot seems to not exist on your system.  Shall I try to install it? [Y/n]> ";
-	    $a = <STDIN>;
-	    $install_flag = !($a =~ m/^\s*n/i);
-	    
-	    unless($install_flag) {
-		print qq{
-
-Okay, I won't install gnuplot. You can still install the Alien::Gnuplot module,
-but it will fail on load until you install the gnuplot executable yourself.
-
-};
-	    }
-
-	} else {
+	if($ENV{AUTOMATED_TESTING}) {
 
 	    if($ENV{PERL_MM_USE_DEFAULT}) {
 		$install_flag = 1;
@@ -113,6 +96,19 @@ so I'll try to install it for you.
 Gnuplot seems to not exist on your system, and this is not an interactive 
 session, so I can't ask if you want to install it.  I'll install the module,
 but it'll fail on load until you install the gnuplot executable yourself.
+
+};
+	    }
+	} else {
+
+	    my $ans = prompt ("\nGnuplot seems to not exist on your system.\nShall I try to install it? [Y/n]> ", 'Y');
+	    $install_flag = !($ans =~ m/^\s*n/i);
+
+	    unless($install_flag) {
+		print qq{
+
+Okay, I won't install gnuplot. You can still install the Alien::Gnuplot module,
+but it will fail on load until you install the gnuplot executable yourself.
 
 };
 	    }


### PR DESCRIPTION
[CPANTS](https://cpants.cpanauthors.org/dist/Alien-Gnuplot) recommends the use of the [prompt](https://metacpan.org/pod/ExtUtils::MakeMaker#prompt) function in preference to explicit reading from STDIN in Makefile.PL. In implementing this I've slightly restructured the logic of that section of the script to take advantage of the inherent features of prompt(). It works fine on my non-MSWin32 systems but since you previously had an explicit check for that O/S it may have some implications of which I am unaware. If you have access to MSWin32 please test it there before merging. Thanks.

This work was done as part of the [CPAN PR Challenge](http://cpan-prc.org/).