### PR TITLE
Build::Copy plugin requires minimum Alien::Build v2.19

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+  - Minimum Alien::Build for Build::Copy plugin is Alien::Build v2.19. Thanks
+    to Andreas K. Hüttel (akhuettel++) for the bug report. GH#11.
 1.040 2023-02-23
   - Switch to using Alien::Build / alienfile to check and install Gnuplot.
   - Alien::Gnuplot is now a subclass of Alien::Base.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -49,7 +49,7 @@ if(exists $ARGV[0] && $ARGV[0] eq 'README.pod')
 my $abmm = Alien::Build::MM->new;
 
 my %configure_and_build_prereqs = (
-    "Alien::Build" => "0.32",
+    "Alien::Build" => "2.19",
     "Alien::Build::MM" => "0.32",
     "ExtUtils::MakeMaker" => "6.52",
 );


### PR DESCRIPTION
Thanks to @akhuettel for the report.

Fixes <https://github.com/drzowie/Alien-Gnuplot/issues/11>.
